### PR TITLE
feat(user) 회원가입 API, Security 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,196 @@
-# kafka-commerce
-kafka를 활용한 커머스
+# kafka-commerce 🛒
+
+**Kafka 기반 비동기 이벤트 커머스 시스템**  
+Spring Boot 기반 멀티모듈 구조로 사용자, 상품, 주문, 결제 도메인을 분리하여 구현하고,  
+Kafka를 활용한 이벤트 기반 주문 처리를 적용한 프로젝트입니다.
+
+---
+
+## 🧩 프로젝트 개요
+
+- **목표**: Kafka 기반의 실시간 주문 처리 시스템 설계 및 구현
+- **특징**:
+  - 멀티모듈 구조로 도메인 책임 분리
+  - Kafka 기반 비동기 이벤트 처리
+  - JWT + Redis 기반 사용자 인증 및 권한 관리
+  - 실무형 예외 응답, 공통 응답 포맷 설계
+
+---
+
+## 🔧 기술 스택
+
+- **Language**: Java 17
+- **Framework**: Spring Boot 3.x
+- **Build Tool**: Gradle (멀티모듈)
+- **Messaging**: Kafka
+- **Database**: MySQL (개발/프로덕션), H2 (테스트)
+- **Security**: Spring Security + JWT
+- **Cache**: Redis (리프레시 토큰 관리)
+- **Test**: JUnit5
+
+---
+
+## 📦 멀티모듈 구성
+
+- `kafka-commerce-common`  
+  → 공통 응답 포맷, 예외 처리, 상수, DTO
+- `kafka-commerce-user`  
+  → 회원가입, 로그인, JWT 인증, 리프레시 토큰 관리
+- `kafka-commerce-product`  
+  → 상품 등록, 조회, 재고 관리 (재고 모듈 통합 여부 미정)
+- `kafka-commerce-order`  
+  → 주문 생성, Kafka 이벤트 발행
+- `kafka-commerce-payment`  
+  → 결제 처리 (카드, 현금, 마일리지), 이벤트 발행
+
+---
+
+## 🧱 주요 기능
+
+### ✅ 회원
+
+- 회원가입, 로그인
+- JWT 발급 (액세스 토큰, 리프레시 토큰)
+- Redis 기반 리프레시 토큰 관리
+- 내 정보 조회
+
+### ✅ 상품
+
+- 상품 등록 (관리자)
+- 상품 목록/상세 조회
+- 재고 관리 (재고 모듈 통합 여부 미정)
+
+### ✅ 주문
+
+- 주문 생성
+- Kafka 주문 이벤트 발행
+- 내 주문 목록 조회
+
+### ✅ 결제
+
+- 결제 처리 (카드, 현금, 마일리지)
+- 실제 PG 연동 없음
+- 결제 상태 관리
+- Kafka 결제 이벤트 발행
+
+---
+
+## 📩 Kafka 이벤트 설계
+
+- **OrderCreatedEvent**  
+  `order` → `product`, `payment`  
+  → 주문 생성 시 발행
+
+- **PaymentCompletedEvent**  
+  `payment` → `order`  
+  → 결제 성공 시 주문 상태 변경
+
+- **PaymentFailedEvent**  
+  `payment` → `order`  
+  → 결제 실패 시 주문 실패 처리
+
+---
+
+## 🔐 보안 설계
+
+### JWT 토큰 관리
+- 액세스 토큰: JWT
+- 리프레시 토큰: Redis 저장
+- 토큰 갱신 프로세스
+- 환경별 보안 설정 (개발/테스트/프로덕션)
+
+### 데이터베이스 보안
+- 환경별 데이터베이스 설정
+- Flyway 마이그레이션
+- 사용자 권한 관리
+
+---
+
+## 🛠 개발 환경
+
+### 데이터베이스
+- 개발: MySQL (kafka_commerce_dev)
+- 테스트: H2
+- 프로덕션: MySQL (kafka_commerce_prod)
+
+### Redis
+- 리프레시 토큰 저장
+- 토큰 만료 관리
+
+### Kafka
+- 로컬 개발 환경 설정
+- 토픽 구성
+- 파티션 전략
+
+---
+
+## 📝 API 문서
+
+### 공통 응답 형식
+```json
+{
+  "code": "SUCCESS",
+  "message": "성공",
+  "data": {}
+}
+```
+
+### 주요 API 엔드포인트
+- User: /api/auth/*, /api/users/*
+- Product: /api/products/*
+- Order: /api/orders/*
+- Payment: /api/payments/*
+
+---
+
+## 🔍 테스트 전략
+
+### 단위 테스트
+- 각 모듈의 핵심 비즈니스 로직
+- 서비스 레이어
+- 유틸리티 클래스
+
+### 통합 테스트
+- API 엔드포인트
+- Kafka 이벤트 처리
+- 데이터베이스 연동
+
+---
+
+## 🚀 배포 전략
+
+### 환경 구성
+- 개발 환경 (로컬)
+- 테스트 환경
+- 프로덕션 환경
+
+### CI/CD
+- GitHub Actions를 통한 자동화
+- 환경별 배포 파이프라인
+
+---
+
+## 📊 모니터링
+
+### 로깅
+- 로그 레벨 설정
+- 로그 포맷
+- 로그 수집 전략
+
+### 메트릭
+- API 응답 시간
+- Kafka 메시지 처리량
+- 데이터베이스 성능
+
+---
+
+## 🧑‍💻 로컬 실행 방법
+
+```bash
+# Kafka, Zookeeper, MySQL 실행 필요
+$ ./gradlew clean build
+$ cd kafka-commerce-user
+$ ./gradlew bootRun
+```
+
+---

--- a/kafka-commerce-common/src/main/java/com/kafkacommerce/common/exception/ErrorCode.java
+++ b/kafka-commerce-common/src/main/java/com/kafkacommerce/common/exception/ErrorCode.java
@@ -1,25 +1,33 @@
 package com.kafkacommerce.common.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
-@RequiredArgsConstructor
 public enum ErrorCode {
-    // 공통 에러
-    INVALID_INPUT_VALUE("C001", "잘못된 입력값입니다."),
-    METHOD_NOT_ALLOWED("C002", "지원하지 않는 HTTP 메소드입니다."),
-    INTERNAL_SERVER_ERROR("C003", "서버 내부 오류가 발생했습니다."),
-    
-    // 인증/권한 에러
-    UNAUTHORIZED("A001", "인증이 필요합니다."),
-    FORBIDDEN("A002", "접근 권한이 없습니다."),
-    
-    // 비즈니스 에러
-    ENTITY_NOT_FOUND("B001", "엔티티를 찾을 수 없습니다."),
-    DUPLICATE_ENTITY("B002", "이미 존재하는 엔티티입니다."),
-    INVALID_STATE("B003", "잘못된 상태입니다.");
+    // 인증 관련 에러
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 영문 대소문자, 숫자, 특수문자를 포함한 8자리 이상이어야 합니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 형식입니다."),
+    INVALID_NAME(HttpStatus.BAD_REQUEST, "이름은 2자 이상 20자 이하여야 합니다."),
 
-    private final String code;
+    // 토큰 관련 에러
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+
+    // 사용자 관련 에러
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    INVALID_USER(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자입니다."),
+
+    // 서버 에러
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus status;
     private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
 } 

--- a/kafka-commerce-common/src/main/java/com/kafkacommerce/common/exception/GlobalExceptionHandler.java
+++ b/kafka-commerce-common/src/main/java/com/kafkacommerce/common/exception/GlobalExceptionHandler.java
@@ -1,39 +1,45 @@
 package com.kafkacommerce.common.exception;
 
 import com.kafkacommerce.common.response.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(e.getMessage(), e.getErrorCode().getCode()));
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getDefaultMessage())
+                .findFirst()
+                .orElse("유효하지 않은 요청입니다.");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(errorMessage));
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(
-                        e.getBindingResult().getAllErrors().get(0).getDefaultMessage(),
-                        ErrorCode.INVALID_INPUT_VALUE.getCode()
-                ));
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolationException(ConstraintViolationException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(e.getMessage()));
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        return ResponseEntity.status(e.getErrorCode().getStatus())
+                .body(ApiResponse.error(e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error(
-                        e.getMessage(),
-                        ErrorCode.INTERNAL_SERVER_ERROR.getCode()
-                ));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("서버 내부 오류가 발생했습니다."));
     }
 } 

--- a/kafka-commerce-common/src/main/java/com/kafkacommerce/common/response/ApiResponse.java
+++ b/kafka-commerce-common/src/main/java/com/kafkacommerce/common/response/ApiResponse.java
@@ -7,19 +7,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ApiResponse<T> {
     private final boolean success;
-    private final T data;
     private final String message;
-    private final String errorCode;
-
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, data, null, null);
-    }
+    private final T data;
 
     public static <T> ApiResponse<T> success(T data, String message) {
-        return new ApiResponse<>(true, data, message, null);
+        return new ApiResponse<>(true, message, data);
     }
 
-    public static <T> ApiResponse<T> error(String message, String errorCode) {
-        return new ApiResponse<>(false, null, message, errorCode);
+    public static <T> ApiResponse<T> success(String message) {
+        return new ApiResponse<>(true, message, null);
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(false, message, null);
     }
 } 

--- a/kafka-commerce-common/src/main/resources/db/migration/V1__create_database_and_users.sql
+++ b/kafka-commerce-common/src/main/resources/db/migration/V1__create_database_and_users.sql
@@ -1,0 +1,20 @@
+-- 개발 환경 (dev) 스키마 및 사용자 생성
+CREATE DATABASE IF NOT EXISTS kafka_commerce_dev CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE USER IF NOT EXISTS 'kafka_commerce_dev'@'localhost' IDENTIFIED BY '1234';
+CREATE USER IF NOT EXISTS 'kafka_commerce_dev'@'%' IDENTIFIED BY '1234';
+
+GRANT ALL PRIVILEGES ON kafka_commerce_dev.* TO 'kafka_commerce_dev'@'localhost';
+GRANT ALL PRIVILEGES ON kafka_commerce_dev.* TO 'kafka_commerce_dev'@'%';
+
+-- 프로덕션 환경 (prod) 스키마 및 사용자 생성
+CREATE DATABASE IF NOT EXISTS kafka_commerce_prod CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE USER IF NOT EXISTS 'kafka_commerce_prod'@'localhost' IDENTIFIED BY '1234';
+CREATE USER IF NOT EXISTS 'kafka_commerce_prod'@'%' IDENTIFIED BY '1234';
+
+GRANT ALL PRIVILEGES ON kafka_commerce_prod.* TO 'kafka_commerce_prod'@'localhost';
+GRANT ALL PRIVILEGES ON kafka_commerce_prod.* TO 'kafka_commerce_prod'@'%';
+
+-- 권한 적용
+FLUSH PRIVILEGES; 

--- a/kafka-commerce-user/build.gradle
+++ b/kafka-commerce-user/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/kafka-commerce-user/build.gradle
+++ b/kafka-commerce-user/build.gradle
@@ -28,6 +28,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    
+    // Common 모듈 의존성
+    implementation project(':kafka-commerce-common')
+    
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/KafkaCommerceUserApplication.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/KafkaCommerceUserApplication.java
@@ -2,8 +2,10 @@ package com.kafkacommerce.user;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan(basePackages = {"com.kafkacommerce.common", "com.kafkacommerce.user"})
 public class KafkaCommerceUserApplication {
 
     public static void main(String[] args) {

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/config/SecurityConfig.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.kafkacommerce.user.config;
+
+import com.kafkacommerce.user.security.JwtAuthenticationFilter;
+import com.kafkacommerce.user.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider tokenProvider;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/auth/**").permitAll()
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/controller/AuthController.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/controller/AuthController.java
@@ -1,0 +1,34 @@
+package com.kafkacommerce.user.controller;
+
+import com.kafkacommerce.common.response.ApiResponse;
+import com.kafkacommerce.user.dto.request.LoginRequest;
+import com.kafkacommerce.user.dto.request.SignUpRequest;
+import com.kafkacommerce.user.dto.response.LoginResponse;
+import com.kafkacommerce.user.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Void>> signUp(@Valid @RequestBody SignUpRequest request) {
+        authService.signUp(request);
+        return ResponseEntity.ok(ApiResponse.success("회원가입이 완료되었습니다."));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
+        return ResponseEntity.ok(ApiResponse.success(response, "로그인이 완료되었습니다."));
+    }
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/controller/AuthController.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/controller/AuthController.java
@@ -4,14 +4,16 @@ import com.kafkacommerce.common.response.ApiResponse;
 import com.kafkacommerce.user.dto.request.LoginRequest;
 import com.kafkacommerce.user.dto.request.SignUpRequest;
 import com.kafkacommerce.user.dto.response.LoginResponse;
+import com.kafkacommerce.user.dto.response.TokenResponse;
 import com.kafkacommerce.user.service.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -27,8 +29,62 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
-        LoginResponse response = authService.login(request);
-        return ResponseEntity.ok(ApiResponse.success(response, "로그인이 완료되었습니다."));
+    public ResponseEntity<ApiResponse<LoginResponse>> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response) {
+        TokenResponse tokenResponse = authService.login(request);
+
+        // 리프레시 토큰을 httpOnly 쿠키로 설정
+        Cookie refreshCookie = new Cookie("refreshToken", tokenResponse.getRefreshToken());
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setSecure(true); // HTTPS에서만 전송
+        refreshCookie.setPath("/");
+        refreshCookie.setMaxAge(60 * 60 * 24 * 14); // 14일
+        response.addCookie(refreshCookie);
+
+        LoginResponse loginResponse = LoginResponse.builder()
+                .email(request.getEmail())
+                .accessToken(tokenResponse.getAccessToken())
+                .build();
+
+        return ResponseEntity.ok(ApiResponse.success(loginResponse, "로그인이 완료되었습니다."));
     }
-} 
+
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponse> refresh(
+            @CookieValue(name = "refreshToken") String refreshToken,
+            HttpServletResponse response) {
+        TokenResponse tokenResponse = authService.refreshAccessToken(refreshToken);
+        
+        // 새로운 리프레시 토큰을 httpOnly 쿠키로 설정
+        Cookie refreshCookie = new Cookie("refreshToken", tokenResponse.getRefreshToken());
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setSecure(true);
+        refreshCookie.setPath("/");
+        refreshCookie.setMaxAge(60 * 60 * 24 * 14);
+        response.addCookie(refreshCookie);
+
+        LoginResponse loginResponse = LoginResponse.builder()
+                .accessToken(tokenResponse.getAccessToken())
+                .build();
+
+        return ResponseEntity.ok(loginResponse);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @CookieValue(name = "refreshToken") String refreshToken,
+            HttpServletResponse response) {
+        authService.logout(refreshToken);
+        
+        // 리프레시 토큰 쿠키 삭제
+        Cookie refreshCookie = new Cookie("refreshToken", null);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setSecure(true);
+        refreshCookie.setPath("/");
+        refreshCookie.setMaxAge(0);
+        response.addCookie(refreshCookie);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/domain/User.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/domain/User.java
@@ -1,0 +1,41 @@
+package com.kafkacommerce.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    private User(String email, String password, String name, UserRole role) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.role = role;
+    }
+
+    public static User createUser(String email, String password, String name) {
+        return new User(email, password, name, UserRole.USER);
+    }
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/domain/UserRole.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/domain/UserRole.java
@@ -1,0 +1,6 @@
+package com.kafkacommerce.user.domain;
+
+public enum UserRole {
+    USER,
+    ADMIN
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/dto/request/LoginRequest.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/dto/request/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.kafkacommerce.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    private String password;
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/dto/request/RefreshRequest.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/dto/request/RefreshRequest.java
@@ -1,0 +1,10 @@
+package com.kafkacommerce.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshRequest {
+    private String refreshToken;
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/dto/request/SignUpRequest.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/dto/request/SignUpRequest.java
@@ -1,0 +1,31 @@
+package com.kafkacommerce.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Setter
+@AllArgsConstructor
+public class SignUpRequest {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    @Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,}$",
+        message = "비밀번호는 영문 대소문자, 숫자, 특수문자(!@#$%^&*)를 포함한 8자리 이상이어야 합니다."
+    )
+    private String password;
+
+    @NotBlank(message = "이름은 필수 입력값입니다.")
+    private String name;
+
+}

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/dto/response/LoginResponse.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/dto/response/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.kafkacommerce.user.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LoginResponse {
+    private final String accessToken;
+    private final String tokenType = "Bearer";
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/dto/response/TokenResponse.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/dto/response/TokenResponse.java
@@ -1,15 +1,11 @@
 package com.kafkacommerce.user.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 @Builder
-public class LoginResponse {
-    private String email;
+public class TokenResponse {
     private String accessToken;
     private String refreshToken;
-    private final String tokenType = "Bearer";
 } 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/repository/UserRepository.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.kafkacommerce.user.repository;
+
+import com.kafkacommerce.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/security/CustomUserDetailsService.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/security/CustomUserDetailsService.java
@@ -1,0 +1,24 @@
+package com.kafkacommerce.user.security;
+
+import com.kafkacommerce.user.domain.User;
+import com.kafkacommerce.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+        
+        return new UserPrincipal(user);
+    }
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/security/JwtAuthenticationFilter.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/security/JwtAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package com.kafkacommerce.user.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        
+        String jwt = getJwtFromRequest(request);
+
+        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+            Authentication authentication = tokenProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/security/JwtTokenProvider.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/security/JwtTokenProvider.java
@@ -1,0 +1,80 @@
+package com.kafkacommerce.user.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final CustomUserDetailsService userDetailsService;
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expiration;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public String generateToken(Authentication authentication) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expiration);
+
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(key)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(claims.getSubject());
+
+        return new UsernamePasswordAuthenticationToken(
+            userDetails, 
+            token, 
+            userDetails.getAuthorities()
+        );
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT signature");
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT token");
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT token");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT token compact of handler are invalid");
+        }
+        return false;
+    }
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/security/UserPrincipal.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/security/UserPrincipal.java
@@ -1,0 +1,57 @@
+package com.kafkacommerce.user.security;
+
+import com.kafkacommerce.user.domain.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class UserPrincipal implements UserDetails {
+
+    private final User user;
+
+    public UserPrincipal(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+            new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
+        );
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/service/AuthService.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/service/AuthService.java
@@ -6,6 +6,7 @@ import com.kafkacommerce.user.domain.User;
 import com.kafkacommerce.user.dto.request.LoginRequest;
 import com.kafkacommerce.user.dto.request.SignUpRequest;
 import com.kafkacommerce.user.dto.response.LoginResponse;
+import com.kafkacommerce.user.dto.response.TokenResponse;
 import com.kafkacommerce.user.repository.UserRepository;
 import com.kafkacommerce.user.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -24,11 +25,12 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider tokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @Transactional
     public void signUp(SignUpRequest request) {
         if (userRepository.existsByEmail(request.getEmail())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL, "이미 존재하는 이메일입니다.");
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
         }
 
         User user = User.createUser(
@@ -41,7 +43,7 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public LoginResponse login(LoginRequest request) {
+    public TokenResponse login(LoginRequest request) {
         Authentication authentication = authenticationManager.authenticate(
             new UsernamePasswordAuthenticationToken(
                 request.getEmail(),
@@ -49,7 +51,64 @@ public class AuthService {
             )
         );
 
-        String accessToken = tokenProvider.generateToken(authentication);
-        return new LoginResponse(accessToken);
+        String accessToken = tokenProvider.generateAccessToken(authentication);
+        String refreshToken = tokenProvider.generateRefreshToken(authentication.getName());
+
+        Long userId = userRepository.findByEmail(request.getEmail())
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND))
+            .getId();
+            
+        refreshTokenService.saveRefreshToken(userId, refreshToken);
+
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public TokenResponse refreshAccessToken(String refreshToken) {
+        // 1. 리프레시 토큰 유효성 검사
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+
+        // 2. 리프레시 토큰에서 이메일 추출
+        String userEmail = tokenProvider.getEmailFromToken(refreshToken);
+
+        // 3. 레디스에서 리프레시 토큰 조회 및 검증
+        Long userId = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND))
+                .getId();
+
+        String savedRefreshToken = refreshTokenService.getRefreshToken(userId);
+        if (savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
+            throw new BusinessException(ErrorCode.TOKEN_NOT_FOUND);
+        }
+
+        // 4. 새로운 액세스 토큰과 리프레시 토큰 발급
+        String newAccessToken = tokenProvider.generateAccessToken(
+            new UsernamePasswordAuthenticationToken(userEmail, null)
+        );
+        String newRefreshToken = tokenProvider.generateRefreshToken(userEmail);
+
+        // 5. 새로운 리프레시 토큰 저장
+        refreshTokenService.saveRefreshToken(userId, newRefreshToken);
+
+        return TokenResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+    }
+
+    public void logout(String refreshToken) {
+        // 1. 리프레시 토큰에서 이메일 추출
+        String userEmail = tokenProvider.getEmailFromToken(refreshToken);
+
+        // 2. 레디스에서 리프레시 토큰 삭제
+        Long userId = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND))
+                .getId();
+
+        refreshTokenService.deleteRefreshToken(userId);
     }
 } 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/service/AuthService.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/service/AuthService.java
@@ -1,0 +1,55 @@
+package com.kafkacommerce.user.service;
+
+import com.kafkacommerce.common.exception.BusinessException;
+import com.kafkacommerce.common.exception.ErrorCode;
+import com.kafkacommerce.user.domain.User;
+import com.kafkacommerce.user.dto.request.LoginRequest;
+import com.kafkacommerce.user.dto.request.SignUpRequest;
+import com.kafkacommerce.user.dto.response.LoginResponse;
+import com.kafkacommerce.user.repository.UserRepository;
+import com.kafkacommerce.user.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider tokenProvider;
+
+    @Transactional
+    public void signUp(SignUpRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL, "이미 존재하는 이메일입니다.");
+        }
+
+        User user = User.createUser(
+            request.getEmail(),
+            passwordEncoder.encode(request.getPassword()),
+            request.getName()
+        );
+
+        userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public LoginResponse login(LoginRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+            new UsernamePasswordAuthenticationToken(
+                request.getEmail(),
+                request.getPassword()
+            )
+        );
+
+        String accessToken = tokenProvider.generateToken(authentication);
+        return new LoginResponse(accessToken);
+    }
+} 

--- a/kafka-commerce-user/src/main/java/com/kafkacommerce/user/service/RefreshTokenService.java
+++ b/kafka-commerce-user/src/main/java/com/kafkacommerce/user/service/RefreshTokenService.java
@@ -1,0 +1,32 @@
+package com.kafkacommerce.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String REFRESH_TOKEN_PREFIX = "refresh:";
+    @Value("${jwt.refresh-expiration}")
+    private long refreshExpiration;
+
+    public void saveRefreshToken(Long userId, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        redisTemplate.opsForValue().set(key, refreshToken, refreshExpiration, TimeUnit.MILLISECONDS);
+    }
+
+    public String getRefreshToken(Long userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteRefreshToken(Long userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        redisTemplate.delete(key);
+    }
+} 

--- a/kafka-commerce-user/src/main/resources/application-dev.yml
+++ b/kafka-commerce-user/src/main/resources/application-dev.yml
@@ -27,7 +27,14 @@ logging:
   level:
     root: INFO
     com.kafkacommerce: DEBUG
+    org.springframework.web: DEBUG        # 웹 요청 관련 로그
+    org.springframework.boot.autoconfigure: INFO  # 부트 설정 로그
+    org.apache.catalina: INFO             # 톰캣 요청 처리 로그
+
 
 jwt:
   secret: kafka-commerce-jwt-secret-key-dev-256-bits-long-1234567890abcdefghijklmnopqrstuvwxyz
-  expiration: 86400000 # 24시간 
+#  expiration: 86400000 # 24시간
+#  refresh-expiration: 1209600000 # 14일
+  expiration: 60000 # 24시간
+  refresh-expiration: 120000 # 14일

--- a/kafka-commerce-user/src/main/resources/application-dev.yml
+++ b/kafka-commerce-user/src/main/resources/application-dev.yml
@@ -1,0 +1,33 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/kafka_commerce_dev?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: kafka_commerce_dev
+    password: 1234
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      force: true
+      enabled: true
+
+logging:
+  level:
+    root: INFO
+    com.kafkacommerce: DEBUG
+
+jwt:
+  secret: kafka-commerce-jwt-secret-key-dev-256-bits-long-1234567890abcdefghijklmnopqrstuvwxyz
+  expiration: 86400000 # 24시간 

--- a/kafka-commerce-user/src/main/resources/application-prod.yml
+++ b/kafka-commerce-user/src/main/resources/application-prod.yml
@@ -1,0 +1,32 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/kafka_commerce_prod?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: kafka_commerce_prod
+    password: 1234
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+  h2:
+    console:
+      enabled: false
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      force: true
+      enabled: true
+
+logging:
+  level:
+    root: INFO
+    com.kafkacommerce: INFO
+
+jwt:
+  secret: ${JWT_SECRET_KEY:prod-secret-key-256-bits-long-1234567890abcdefghijklmnopqrstuvwxyz}
+  expiration: 86400000 # 24시간 

--- a/kafka-commerce-user/src/main/resources/application-test.yml
+++ b/kafka-commerce-user/src/main/resources/application-test.yml
@@ -1,6 +1,4 @@
 spring:
-  profiles:
-    active: dev  # 기본적으로 dev 프로파일을 활성화
   datasource:
     url: jdbc:h2:mem:testdb
     driver-class-name: org.h2.Driver
@@ -25,6 +23,11 @@ server:
       force: true
       enabled: true
 
+logging:
+  level:
+    root: INFO
+    com.kafkacommerce: DEBUG
+
 jwt:
-  secret: kafka-commerce-jwt-secret-key-256-bits-long-1234567890abcdefghijklmnopqrstuvwxyz
+  secret: test-jwt-secret-key-256-bits-long-1234567890abcdefghijklmnopqrstuvwxyz
   expiration: 86400000 # 24시간 

--- a/kafka-commerce-user/src/main/resources/application.properties
+++ b/kafka-commerce-user/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=kafka-commerce-user

--- a/kafka-commerce-user/src/main/resources/application.yml
+++ b/kafka-commerce-user/src/main/resources/application.yml
@@ -2,13 +2,13 @@ spring:
   profiles:
     active: dev  # 기본적으로 dev 프로파일을 활성화
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:mysql://localhost:3306/kafka_commerce?createDatabaseIfNotExist=true
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
@@ -17,6 +17,10 @@ spring:
     console:
       enabled: true
       path: /h2-console
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 server:
   servlet:
@@ -27,4 +31,9 @@ server:
 
 jwt:
   secret: kafka-commerce-jwt-secret-key-256-bits-long-1234567890abcdefghijklmnopqrstuvwxyz
-  expiration: 86400000 # 24시간 
+  expiration: 3600000 # 1시간
+  refresh-expiration: 1209600000 # 14일
+
+logging:
+  level:
+    com.kafkacommerce: DEBUG 

--- a/kafka-commerce-user/src/main/resources/application.yml
+++ b/kafka-commerce-user/src/main/resources/application.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      force: true
+      enabled: true
+
+jwt:
+  secret: kafka-commerce-jwt-secret-key-256-bits-long-1234567890abcdefghijklmnopqrstuvwxyz
+  expiration: 86400000 # 24시간 

--- a/kafka-commerce-user/src/test/java/com/kafkacommerce/user/controller/AuthControllerTest.java
+++ b/kafka-commerce-user/src/test/java/com/kafkacommerce/user/controller/AuthControllerTest.java
@@ -1,0 +1,46 @@
+package com.kafkacommerce.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kafkacommerce.user.dto.request.SignUpRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("유효하지 않은 비밀번호로 회원가입 시도 시 GlobalExceptionHandler가 동작해야 한다")
+    void signUp_withInvalidPassword_shouldReturnBadRequest() throws Exception {
+        // given
+        SignUpRequest request = new SignUpRequest("test@test.com", "invalid", "테스트");
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        // when
+        MvcResult result = mockMvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        // then
+        String responseBody = result.getResponse().getContentAsString();
+        assertThat(responseBody).contains("비밀번호는 영문 대소문자, 숫자, 특수문자(!@#$%^&*)를 포함한 8자리 이상이어야 합니다.");
+    }
+} 

--- a/kafka-commerce-user/src/test/java/com/kafkacommerce/user/controller/AuthControllerTest.java
+++ b/kafka-commerce-user/src/test/java/com/kafkacommerce/user/controller/AuthControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -17,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class AuthControllerTest {
 
     @Autowired


### PR DESCRIPTION
feat(user): 리프레시 토큰 httpOnly 쿠키 적용 및 인증 구조 개선

- 리프레시 토큰을 더 이상 바디에 포함하지 않고 httpOnly 쿠키로만 전송하도록 변경
- 로그인, 토큰 재발급, 로그아웃 시 쿠키에 리프레시 토큰을 설정/삭제
- 컨트롤러에서 쿠키로 리프레시 토큰을 읽어 인증 처리
- AuthService, LoginResponse 등 관련 로직 및 DTO 구조 개선
- JWT에서 이메일 추출 메소드 추가
- 실무 보안 패턴에 맞춰 응답 바디에는 accessToken만 포함

feat(user): 설정 분리, DB 스키마 추가

- application test,dev,prod 추가
- database SQL 추가

feat(user): 회원가입 API 유효성 검사 구현

- SignUpRequest 비밀번호 유효성 검사 패턴 수정
- AuthController 테스트 코드 추가
- 한글 인코딩 설정 추가

feat(common): 공통 응답 포맷 및 예외 처리 기능 변경

- GlobalExceptionHandler 변경
- ApiResponse 응답 형식 변경
- ErrorCode 코드값 변경